### PR TITLE
fix debian 8 package building, fixes #39

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,5 +26,5 @@ TMP     = $(CURDIR)/debian/$(PACKAGE)
 
 override_dh_auto_install:
 	dh_auto_install
-	find $(TMP) -name '*.la' | xargs rm --verbose
+	find $(TMP) -name '*.la' | xargs rm --verbose || true
 


### PR DESCRIPTION
Fix dpkg-buildpackage which fails on Raspbian8