### PR TITLE
Handle camera hot unplugging more gracefully

### DIFF
--- a/src/RaspiCapture.c
+++ b/src/RaspiCapture.c
@@ -752,8 +752,9 @@ static void camera_control_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
          break;
       }
    }
-   else
-   {
+   else if (buffer->cmd == MMAL_EVENT_ERROR) {
+      vcos_log_error("Camera control callback got an error");
+   } else {
       vcos_log_error("Received unexpected camera control callback event, 0x%08x", buffer->cmd);
    }
 

--- a/src/RaspiCapture.c
+++ b/src/RaspiCapture.c
@@ -938,8 +938,12 @@ raspi_capture_fill_buffer(RASPIVID_STATE *state, GstBuffer **bufp,
   GstClockTime gst_pts = GST_CLOCK_TIME_NONE;
 
   /* FIXME: Use our own interruptible cond wait: */
-  buffer = mmal_queue_wait(state->encoded_buffer_q);
 
+  buffer = mmal_queue_timedwait(state->encoded_buffer_q, 100);
+
+  if (G_UNLIKELY(buffer == NULL)) {
+      return GST_FLOW_ERROR;
+  }
 
   if (G_LIKELY (config->useSTC && clock)) {
     MMAL_PARAMETER_INT64_T param;


### PR DESCRIPTION
In case an external camera got disconnected there were no way for an application to know.

This PR addresses #65. 

I propose to use `mmal_queue_timedwait()` with a reasonable timeout set to 100ms.

I tested it with a HDMI to CSI-2 TC358743 bridge with an external camera and a demo application that tries rebuilding the pipeline upon an error that it gets from the bus. The error is triggered by unplugging the camera. As soon as camera is connected back again the stream continues.