### PR TITLE
fix gstplugin.map for gstreamer 1.17

### DIFF
--- a/src/gstplugin.map
+++ b/src/gstplugin.map
@@ -1,3 +1,3 @@
 { global:
-gst_plugin_desc;
+gst_plugin_rpicamsrc_get_desc;
 local: *; };


### PR DESCRIPTION
without this libgstrpicam.so is not detected by gst-inspect-1.0

This fix has been suggested to me on IRC FreeNode #gstreamer channel.