### PR TITLE
Introduce retry attempts on mmal_queue_timedwait

### DIFF
--- a/src/RaspiCapture.c
+++ b/src/RaspiCapture.c
@@ -932,7 +932,7 @@ raspi_capture_fill_buffer(RASPIVID_STATE *state, GstBuffer **bufp,
 {
   RASPIVID_CONFIG *config = &state->config;
   GstBuffer *buf = NULL;
-  MMAL_BUFFER_HEADER_T *buffer;
+  MMAL_BUFFER_HEADER_T *buffer = NULL;
   GstFlowReturn ret = GST_FLOW_ERROR;
   /* No timestamps if no clockm or invalid PTS */
   GstClockTime gst_pts = GST_CLOCK_TIME_NONE;


### PR DESCRIPTION
This attempts to resolve spurious errors seen as `GST_FLOW_ERROR_TIMEOUT`:
```
        "Camera capture timed out."
        "Waiting for a buffer from the camera took too long."
```
The fix introduced is a simple retry mechanism, up to three attempts, which seems to address the problem when `mmal_queue_timedwait()` is called. 

It's unclear to me as to why `mmal_queue_timedwait()` fails in the first place, this is by no means an absolute fix but rather a recovery mechanism.