### PR TITLE
meson: use gnome.glib_mkenums_simple() and fix build as Meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gst-rpicamsrc', 'c', version : '1.0.0',
-  meson_version : '>= 0.34.0', default_options : ['b_asneeded=false'])
+  meson_version : '>= 0.42.0', default_options : ['b_asneeded=false'])
 add_project_link_arguments('-Wl,--no-as-needed', language: 'c')
 
 gst_req = '>= 1.0.0'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,10 +17,10 @@ libgstrpicamsrc_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
 libgstrpicamsrc_la_LIBTOOLFLAGS = --tag=disable-static
 
 gstrpicam-enum-types.h: gstrpicam-enums-template.h $(ENUM_FILES) $(GLIB_MKENUMS)
-	$(AM_V_GEN) (cd $(srcdir) && $(GLIB_MKENUMS) --template gstrpicam-enums-template.h $(ENUM_FILES)) > $@
+	$(AM_V_GEN) (cd $(srcdir) && $(GLIB_MKENUMS) --template gstrpicam-enums-template.h --identifier-prefix GstRpiCamSrc --symbol-prefix gst_rpi_cam_src $(ENUM_FILES)) > $@
 
 gstrpicam-enum-types.c: gstrpicam-enum-types.h gstrpicam-enums-template.c $(ENUM_FILES) $(GLIB_MKENUMS)
-	$(AM_V_GEN) (cd $(srcdir) && $(GLIB_MKENUMS) --template gstrpicam-enums-template.c $(ENUM_FILES)) > $@
+	$(AM_V_GEN) (cd $(srcdir) && $(GLIB_MKENUMS) --template gstrpicam-enums-template.c --identifier-prefix GstRpiCamSrc --symbol-prefix gst_rpi_cam_src $(ENUM_FILES)) > $@
 
 noinst_HEADERS = gstrpicamsrc.h RaspiCapture.h RaspiCamControl.h \
     RaspiPreview.h RaspiCLI.h \

--- a/src/gstrpicam-enums-template.c
+++ b/src/gstrpicam-enums-template.c
@@ -4,8 +4,11 @@
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 #include "@filename@"
+
+#define C_ENUM(v) ((gint) v)
+#define C_FLAGS(v) ((guint) v)
 
 /*** END file-production ***/
 
@@ -13,27 +16,24 @@
 GType
 @enum_name@_get_type (void)
 {
-	static GType the_type = 0;
-	
-	if (the_type == 0)
-	{
-		static const G@Type@Value values[] = {
+  static volatile gsize gtype_id = 0;
+
+  if (g_once_init_enter (&gtype_id)) {
+    static const G@Type@Value values[] = {
 /*** END value-header ***/
 
 /*** BEGIN value-production ***/
-			{ @VALUENAME@,
-			  "@VALUENAME@",
-			  "@valuenick@" },
+        { C_@TYPE@(@VALUENAME@), "@VALUENAME@", "@valuenick@" },
 /*** END value-production ***/
 
 /*** BEGIN value-tail ***/
-			{ 0, NULL, NULL }
-		};
-		the_type = g_@type@_register_static (
-				g_intern_static_string ("@EnumName@"),
-				values);
-	}
-	return the_type;
+        { 0, NULL, NULL }
+    };
+
+    GType new_type = g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
+    g_once_init_leave (&gtype_id, new_type);
+  }
+  return (GType) gtype_id;
 }
 
 /*** END value-tail ***/

--- a/src/gstrpicam-enums-template.h
+++ b/src/gstrpicam-enums-template.h
@@ -1,6 +1,5 @@
 /*** BEGIN file-header ***/
-#ifndef __GSTRPICAM_ENUM_TYPES_H__
-#define __GSTRPICAM_ENUM_TYPES_H__
+#pragma once
 
 #include <glib-object.h>
 
@@ -9,18 +8,17 @@ G_BEGIN_DECLS
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-/* Enumerations from "@filename@" */
+/* Enumerations from "@basename@" */
 
 /*** END file-production ***/
 
 /*** BEGIN enumeration-production ***/
-#define GST_RPI_CAM_TYPE_@ENUMSHORT@	(@enum_name@_get_type())
-GType @enum_name@_get_type	(void) G_GNUC_CONST;
+#define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type())
+GType @enum_name@_get_type (void);
 
 /*** END enumeration-production ***/
 
 /*** BEGIN file-tail ***/
 G_END_DECLS
 
-#endif /* __GSTRPICAM_ENUM_TYPES_H__ */
 /*** END file-tail ***/

--- a/src/gstrpicamsrc.c
+++ b/src/gstrpicamsrc.c
@@ -375,21 +375,21 @@ gst_rpi_cam_src_class_init (GstRpiCamSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_EXPOSURE_MODE,
       g_param_spec_enum ("exposure-mode", "Exposure Mode",
           "Camera exposure mode to use",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_EXPOSURE_MODE, EXPOSURE_MODE_DEFAULT,
+          GST_RPI_CAM_SRC_TYPE_EXPOSURE_MODE, EXPOSURE_MODE_DEFAULT,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_EXPOSURE_METERING_MODE,
       g_param_spec_enum ("metering-mode", "Exposure Metering Mode",
           "Camera exposure metering mode to use",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_EXPOSURE_METERING_MODE,
+          GST_RPI_CAM_SRC_TYPE_EXPOSURE_METERING_MODE,
           EXPOSURE_METERING_MODE_DEFAULT,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_DRC,
       g_param_spec_enum ("drc", "DRC level", "Dynamic Range Control level",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_DRC_LEVEL, GST_RPI_CAM_SRC_DRC_LEVEL_OFF,
+          GST_RPI_CAM_SRC_TYPE_DRC_LEVEL, GST_RPI_CAM_SRC_DRC_LEVEL_OFF,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_AWB_MODE,
       g_param_spec_enum ("awb-mode", "Automatic White Balance Mode",
-          "White Balance mode", GST_RPI_CAM_TYPE_RPI_CAM_SRC_AWB_MODE,
+          "White Balance mode", GST_RPI_CAM_SRC_TYPE_AWB_MODE,
           GST_RPI_CAM_SRC_AWB_MODE_AUTO,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_AWB_GAIN_RED,
@@ -403,7 +403,7 @@ gst_rpi_cam_src_class_init (GstRpiCamSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_IMAGE_EFFECT,
       g_param_spec_enum ("image-effect", "Image effect",
           "Visual FX to apply to the image",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_IMAGE_EFFECT,
+          GST_RPI_CAM_SRC_TYPE_IMAGE_EFFECT,
           GST_RPI_CAM_SRC_IMAGEFX_NONE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 #if 0
@@ -461,7 +461,7 @@ gst_rpi_cam_src_class_init (GstRpiCamSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_ANNOTATION_MODE,
       g_param_spec_flags ("annotation-mode", "Annotation Mode",
           "Flags to control annotation of the output video",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_ANNOTATION_MODE, 0,
+          GST_RPI_CAM_SRC_TYPE_ANNOTATION_MODE, 0,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_ANNOTATION_TEXT,
       g_param_spec_string ("annotation-text", "Annotation Text",
@@ -470,7 +470,7 @@ gst_rpi_cam_src_class_init (GstRpiCamSrcClass * klass)
   g_object_class_install_property (gobject_class, PROP_INTRA_REFRESH_TYPE,
       g_param_spec_enum ("intra-refresh-type", "Intra Refresh Type",
           "Type of Intra Refresh to use, -1 to disable intra refresh",
-          GST_RPI_CAM_TYPE_RPI_CAM_SRC_INTRA_REFRESH_TYPE,
+          GST_RPI_CAM_SRC_TYPE_INTRA_REFRESH_TYPE,
           GST_RPI_CAM_SRC_INTRA_REFRESH_TYPE_NONE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_ANNOTATION_TEXT_SIZE,

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,26 +7,18 @@ rpicamsrc_sources = [
   'RaspiCLI.c',
 ]
 
-# This can be simplified once meson gets native support for glib-mkenums (soon)
-glib_mkenums = find_program('glib-mkenums')
+# glib-mkenums
+gnome = import('gnome')
 
-gstrpicam_enum_types_h = custom_target('gstrpicam-enum-types.h',
-  output : 'gstrpicam-enum-types.h',
-  input : files('gstrpicam_types.h'),
-  command : [glib_mkenums, '--template', meson.current_source_dir() + '/gstrpicam-enums-template.h', '@INPUT@'],
-  capture : true)
-
-gstrpicam_enum_types_c = custom_target('gstrpicam-enum-types.c',
-  output : 'gstrpicam-enum-types.c',
-  input : files('gstrpicam_types.h'),
-  depends : [gstrpicam_enum_types_h],
-  command : [glib_mkenums, '--template', meson.current_source_dir() + '/gstrpicam-enums-template.c', '@INPUT@'],
-  capture : true)
+enums = gnome.mkenums_simple('gstrpicam-enum-types',
+  sources: 'gstrpicam_types.h',
+  identifier_prefix: 'GstRpiCamSrc',
+  symbol_prefix: 'gst_rpi_cam_src')
 
 mapfile = 'gstplugin.map'
 
 library('gstrpicamsrc',
-  rpicamsrc_sources, gstrpicam_enum_types_h, gstrpicam_enum_types_c,
+  rpicamsrc_sources, enums,
   c_args : gst_rpicamsrc_args,
   include_directories : config_inc,
   link_args : '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile),


### PR DESCRIPTION
While at it also fix up the type defines, e.g. `GST_RPI_CAM_TYPE_RPI_CAM_SRC_EXPOSURE_MODE` -> `GST_RPI_CAM_SRC_TYPE_EXPOSURE_MODE`

And sync up Autotools build accordingly (can we remove it yet?).

Only tested build and that `gst-inspect` works, was done on device without camera attached at the time. But what could possible go wrong, right? :)