### PR TITLE
meson: drop map file and fix plugin symbol export with newer gstreamer versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,11 @@ plugins_install_dir = '@0@/gstreamer-1.0'.format(get_option('libdir'))
 
 cc = meson.get_compiler('c')
 
+# Symbol visibility
+if cc.has_argument('-fvisibility=hidden')
+  add_project_arguments('-fvisibility=hidden', language: 'c')
+endif
+
 rpi_path = get_option('with-rpi-header-dir')
 rpi_paths = ['-I' + rpi_path, '-I' + rpi_path + '/interface/vcos/pthreas', '-I' + rpi_path + '/interface/vmcs_host/linux']
 

--- a/src/gstplugin.map
+++ b/src/gstplugin.map
@@ -1,3 +1,0 @@
-{ global:
-gst_plugin_desc;
-local: *; };

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,14 +23,10 @@ gstrpicam_enum_types_c = custom_target('gstrpicam-enum-types.c',
   command : [glib_mkenums, '--template', meson.current_source_dir() + '/gstrpicam-enums-template.c', '@INPUT@'],
   capture : true)
 
-mapfile = 'gstplugin.map'
-
 library('gstrpicamsrc',
   rpicamsrc_sources, gstrpicam_enum_types_h, gstrpicam_enum_types_c,
   c_args : gst_rpicamsrc_args,
   include_directories : config_inc,
-  link_args : '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile),
-  link_depends : mapfile,
   dependencies : [gst_dep, gstbase_dep, gstvideo_dep] + mmal_deps,
   install : true,
   install_dir : plugins_install_dir)


### PR DESCRIPTION
Use `-fvisibility` instead of a map file for symbol export, so that
the right symbols get exported with newer gstreamer versions. Older
GStreamer versions also still work of course.

Fixes blacklisting/plugin-loading issues with GStreamer >= 1.14

(Autotools build doesn't need updating, it exports everything starting with `gst_` so no problem there.)