### PR TITLE
Added "src->started = FALSE;" to gst_rpi_cam_src_stop

### DIFF
--- a/src/gstrpicamsrc.c
+++ b/src/gstrpicamsrc.c
@@ -1214,6 +1214,7 @@ gst_rpi_cam_src_stop (GstBaseSrc * parent)
     raspi_capture_stop (src->capture_state);
   raspi_capture_free (src->capture_state);
   src->capture_state = NULL;
+  src->started = FALSE;
   return TRUE;
 }
 


### PR DESCRIPTION
Solves the non-reusability problem discussed in #105 